### PR TITLE
Include EB-cli in AWS-cli Dockerfile

### DIFF
--- a/circle-node-awscli/Dockerfile
+++ b/circle-node-awscli/Dockerfile
@@ -5,6 +5,7 @@ FROM circleci/node:$NODE_VERSION
 RUN sudo apt-get update && \
   sudo apt-get install -y python python-pip python-dev && \
   sudo pip install awscli && \
+  sudo pip install awsebcli --upgrade --user && \
   sudo apt-get clean
 
 ENV AWS_ACCESS_KEY_ID=dummy

--- a/circle-node-awscli/Dockerfile
+++ b/circle-node-awscli/Dockerfile
@@ -5,7 +5,7 @@ FROM circleci/node:$NODE_VERSION
 RUN sudo apt-get update && \
   sudo apt-get install -y python python-pip python-dev && \
   sudo pip install awscli && \
-  sudo pip install awsebcli --upgrade --user && \
+  sudo pip install awsebcli --upgrade && \
   sudo apt-get clean
 
 ENV AWS_ACCESS_KEY_ID=dummy


### PR DESCRIPTION
In response to [a deployment issue in the NPM Hook Reciever](https://circleci.com/gh/sagelabs/npm-slack-webhook-receiver/157), I took a look at the [aws cli docs](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/eb-cli3-install.html) and found that the EB command needs to be installed in a different python module, `awsebcli`.

This should either go here, or we could make a separate container specific to EB concerns.