### PR TITLE
Updated Dockerifle to allow node18 install

### DIFF
--- a/cimg-node-awscli/Dockerfile
+++ b/cimg-node-awscli/Dockerfile
@@ -2,11 +2,14 @@ ARG NODE_VERSION=latest
 
 FROM cimg/node:$NODE_VERSION
 
-RUN sudo apt-get update && \
-  sudo apt-get install -y python3 python3-pip python-dev && \
-  sudo pip3 install awscli && \
-  sudo pip3 install awsebcli --upgrade && \
-  sudo apt-get clean
+
+RUN sudo apt-get update
+RUN sudo apt-get install -y python3 python3-pip python3-dev
+RUN sudo pip3 install awscli
+RUN sudo pip install "pyyaml<5.4"
+RUN sudo pip install --upgrade setuptools
+RUN sudo pip3 install awsebcli --upgrade
+
 
 ENV AWS_ACCESS_KEY_ID=dummy
 ENV AWS_SECRET_ACCESS_KEY=dummy


### PR DESCRIPTION
Updated the dockerfile for cimg-node-awscli. It works with spider, but I have not yet tested it for anything else